### PR TITLE
Support for Twig 3

### DIFF
--- a/Twig/Extension/UploaderExtension.php
+++ b/Twig/Extension/UploaderExtension.php
@@ -3,8 +3,10 @@
 namespace Oneup\UploaderBundle\Twig\Extension;
 
 use Oneup\UploaderBundle\Templating\Helper\UploaderHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class UploaderExtension extends \Twig_Extension
+class UploaderExtension extends AbstractExtension
 {
     protected $helper;
 
@@ -21,11 +23,11 @@ class UploaderExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('oneup_uploader_endpoint', [$this, 'endpoint']),
-            new \Twig_SimpleFunction('oneup_uploader_progress', [$this, 'progress']),
-            new \Twig_SimpleFunction('oneup_uploader_cancel', [$this, 'cancel']),
-            new \Twig_SimpleFunction('oneup_uploader_upload_key', [$this, 'uploadKey']),
-            new \Twig_SimpleFunction('oneup_uploader_maxsize', [$this, 'maxSize']),
+            new TwigFunction('oneup_uploader_endpoint', [$this, 'endpoint']),
+            new TwigFunction('oneup_uploader_progress', [$this, 'progress']),
+            new TwigFunction('oneup_uploader_cancel', [$this, 'cancel']),
+            new TwigFunction('oneup_uploader_upload_key', [$this, 'uploadKey']),
+            new TwigFunction('oneup_uploader_maxsize', [$this, 'maxSize']),
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "symfony/framework-bundle": "^3.0|^4.0|^5.0",
         "symfony/templating": "^3.0|^4.0|^5.0",
         "symfony/translation": "^3.0|^4.0|^5.0",
-        "symfony/yaml": "^3.0|^4.0|^5.0"
+        "symfony/yaml": "^3.0|^4.0|^5.0",
+        "twig/twig": "^2.4|^3.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
Add support for Twig 3 because the global `Twig_Extension` and `Twig_SimpleFunction` classes have been deprecated for a while in Twig 2 and removed in Twig 3.

I also added a requirement for Twig 2.4|3.0 to the composer file.